### PR TITLE
make responsive grid for mobile support

### DIFF
--- a/my-docs-site/src/pages/index.module.css
+++ b/my-docs-site/src/pages/index.module.css
@@ -47,10 +47,11 @@
 /* Grid Layout */
 .grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
   gap: 1.5rem;
   margin-top: 3rem;
   max-width: 900px;
+  width: 100%;
 }
 
 /* Card Styling */


### PR DESCRIPTION
add reponsive design allowing the grid to reduce the number of rows with auto-fill, and size the grid to always fill the width of the container

| Before |  After |
|-|-|
|![azure github io_k8s-gh-action-toolkit_(iPhone SE)](https://github.com/user-attachments/assets/43d191b4-8233-4d4c-a4d9-8f50b52e49be) | ![localhost_3000_k8s-gh-action-toolkit_(iPhone SE) (1)](https://github.com/user-attachments/assets/7532b27d-d7d8-4ab9-b418-3d0649f61779) |
| ![azure github io_k8s-gh-action-toolkit_(iPad Mini)](https://github.com/user-attachments/assets/30245c37-8306-4a20-8697-d92467e2de7b)| ![localhost_3000_k8s-gh-action-toolkit_(iPad Mini)](https://github.com/user-attachments/assets/ff073962-abca-4123-9f46-740036762343)|
