### PR TITLE
fix another place for npm build.

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install dependencies
         run: npm install --frozen-lockfile
       - name: Build website
-        run: npm build
+        run: npm run build
 
       - name: Upload Build Artifact
         uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa


### PR DESCRIPTION
This PR fixes the extension of the fix previously done and seems like missed for one file, under this PR:

* https://github.com/Azure/k8s-gh-action-toolkit/pull/8

This should get the build all green. 

Thanks, cc: @ReinierCC + @davidgamero ❤️ 